### PR TITLE
fix: multiple-button-injections

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,8 +15,6 @@ export const OPEN_SAUCED_AI_PR_DESCRIPTION_ENDPOINT = "https://api.opensauced.pi
 // GitHub constants/selectors
 export const GITHUB_PROFILE_MENU_SELECTOR = ".p-nickname.vcard-username.d-block";
 export const GITHUB_PROFILE_EDIT_MENU_SELECTOR = "button.js-profile-editable-edit-button";
-export const GITHUB_PR_AUTHOR_USERNAME_SELECTOR = "author Link--primary text-bold css-overflow-wrap-anywhere";
-export const GITHUB_LOGGED_IN_USER_USERNAME_SELECTOR = "meta[name=\"user-login\"]";
 export const GITHUB_PR_COMMENT_HEADER_SELECTOR = "timeline-comment-header clearfix d-flex";
 export const GITHUB_NEW_PR_COMMENT_EDITOR_SELECTOR = "flex-nowrap d-none d-md-inline-block mr-md-0 mr-3";
 export const GITHUB_PR_COMMENT_EDITOR_SELECTOR = "flex-nowrap d-inline-block mr-3";

--- a/src/content-scripts/github.ts
+++ b/src/content-scripts/github.ts
@@ -15,7 +15,16 @@ import domUpdateWatch from "../utils/dom-utils/domUpdateWatcher";
 import injectDescriptionGeneratorButton from "../utils/dom-utils/addDescriptionGenerator";
 import prEditWatch from "../utils/dom-utils/prEditWatcher";
 
+let navigationHistory = new Set<string>();
+
 const processGithubPage = async () => {
+
+  domUpdateWatch(processGithubPage, 50);
+
+  const location = window.location.href.split('?')[0];
+  if (navigationHistory.has(location)) return;
+  navigationHistory.add(location);
+  
   if (prefersDarkMode(document.cookie)) {
     document.documentElement.classList.add("dark");
   }
@@ -41,8 +50,7 @@ const processGithubPage = async () => {
 
     await injectRepoVotingButtons(ownerName, repoName);
   }
-
-  domUpdateWatch(processGithubPage, 50);
+  
 };
 
 void processGithubPage();

--- a/src/pages/start.tsx
+++ b/src/pages/start.tsx
@@ -2,7 +2,7 @@ import OpenSaucedLogo from "../assets/opensauced-logo.svg";
 import { SUPABASE_LOGIN_URL } from "../constants";
 
 const Start = () => (
-    <div>
+    <div className="p-4 bg-slate-800">
       <img
         alt="Open Sauced Logo"
         src={OpenSaucedLogo}

--- a/src/utils/dom-utils/addDescriptionGenerator.ts
+++ b/src/utils/dom-utils/addDescriptionGenerator.ts
@@ -11,9 +11,6 @@ const injectDescriptionGeneratorButton = async () => {
     const commentFormatRow = document.getElementsByClassName(selector)[0];
     const addGeneratorButton = DescriptionGeneratorButton();
 
-    if (commentFormatRow.firstChild?.isEqualNode(addGeneratorButton)) {
-      return;
-    }
     commentFormatRow.insertBefore(addGeneratorButton, commentFormatRow.firstChild);
 };
 

--- a/src/utils/dom-utils/addPRToHighlights.ts
+++ b/src/utils/dom-utils/addPRToHighlights.ts
@@ -1,38 +1,26 @@
 import { AddPRToHighlightsButton } from "../../content-scripts/components/AddPRToHighlights/AddPRToHighlightsButton";
-import {
-  GITHUB_LOGGED_IN_USER_USERNAME_SELECTOR,
-  GITHUB_PR_AUTHOR_USERNAME_SELECTOR,
-  GITHUB_PR_COMMENT_HEADER_SELECTOR,
-} from "../../constants";
+import { GITHUB_PR_COMMENT_HEADER_SELECTOR } from "../../constants";
 import { isLoggedIn } from "../checkAuthentication";
 import { isPublicRepository } from "../fetchGithubAPIData";
 
 const injectAddPRToHighlightsButton = async () => {
   if (!(await isLoggedIn())) {
- return;
-}
+    return;
+  }
 
-  const prAuthorUserName = document.getElementsByClassName(
-    GITHUB_PR_AUTHOR_USERNAME_SELECTOR,
-  )[0].textContent;
-  const loggedInUserUserName = document
-    .querySelector(GITHUB_LOGGED_IN_USER_USERNAME_SELECTOR)
-    ?.getAttribute("content");
+  if (!(await isPublicRepository(window.location.href))) {
+    return;
+  }
 
-  if (loggedInUserUserName && prAuthorUserName === loggedInUserUserName) {
-    if (!(await isPublicRepository(window.location.href))) {
- return;
-}
-    const commentFormatRow = document.getElementsByClassName(
+  const commentFormatRow = document.getElementsByClassName(
       GITHUB_PR_COMMENT_HEADER_SELECTOR,
     )[0];
-    const addPRToHighlightsButton = AddPRToHighlightsButton();
+  const addPRToHighlightsButton = AddPRToHighlightsButton();
 
-    commentFormatRow.insertBefore(
+  commentFormatRow.insertBefore(
         addPRToHighlightsButton,
         commentFormatRow.lastElementChild,
       );
-  }
 };
 
 export default injectAddPRToHighlightsButton;

--- a/src/utils/dom-utils/addPRToHighlights.ts
+++ b/src/utils/dom-utils/addPRToHighlights.ts
@@ -28,16 +28,10 @@ const injectAddPRToHighlightsButton = async () => {
     )[0];
     const addPRToHighlightsButton = AddPRToHighlightsButton();
 
-    if (
-      !commentFormatRow.lastElementChild?.previousElementSibling?.isEqualNode(
-        addPRToHighlightsButton,
-      )
-    ) {
-      commentFormatRow.insertBefore(
+    commentFormatRow.insertBefore(
         addPRToHighlightsButton,
         commentFormatRow.lastElementChild,
       );
-    }
   }
 };
 

--- a/src/utils/dom-utils/inviteToOpenSauced.ts
+++ b/src/utils/dom-utils/inviteToOpenSauced.ts
@@ -34,10 +34,6 @@ const injectOpenSaucedInviteButton = (username: string) => {
 
   const userBio = document.querySelector(GITHUB_PROFILE_MENU_SELECTOR);
 
-
-  if (userBio?.lastChild?.isEqualNode(inviteToOpenSaucedButton)) {
-    return;
-  }
   userBio?.append(inviteToOpenSaucedButton);
   document.body.appendChild(inviteToOpenSaucedModal);
 };

--- a/src/utils/dom-utils/repoVotingButtons.ts
+++ b/src/utils/dom-utils/repoVotingButtons.ts
@@ -27,14 +27,8 @@ const injectRepoVotingButtons = async (ownerName: string, repoName: string) => {
   const userVotedRepo = await checkUserVotedRepo(userToken, repoName);
 
   if (userVotedRepo) {
-    if (repoActions.lastChild?.isEqualNode(repoUnvoteButton)) {
-      return;
-    }
     repoActions.appendChild(repoUnvoteButton);
   } else {
-    if (repoActions.lastChild?.isEqualNode(voteRepoButton)) {
-      return;
-    }
     repoActions.appendChild(voteRepoButton);
   }
 };

--- a/src/utils/dom-utils/viewOnOpenSauced.ts
+++ b/src/utils/dom-utils/viewOnOpenSauced.ts
@@ -11,9 +11,6 @@ const injectViewOnOpenSaucedButton = (username: string) => {
     `${GITHUB_PROFILE_MENU_SELECTOR}, ${GITHUB_PROFILE_EDIT_MENU_SELECTOR}`,
   );
 
-  if (userBio?.lastChild?.isEqualNode(viewOnOpenSaucedButton)) {
- return;
-}
   userBio?.append(viewOnOpenSaucedButton);
 };
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR proposes a new handler to resolve the multiple button injections issue, avoid it in any future content-script components without the need for guards in the injection scripts. 570f9ac40e679324c1bf5fbef4b58a1eeccd37ce.

### Here's how it works:
* A content-script runs when a page is loaded. In our case `https://github.com`. All of the GitHub processing is done within the [processGithubPage](https://github.com/open-sauced/ai/blob/554bdedef96f35b1e967d1dd2cd934b2158fcda2/src/content-scripts/github.ts#L18) function of the content-script. https://github.com/open-sauced/ai/blob/554bdedef96f35b1e967d1dd2cd934b2158fcda2/src/content-scripts/github.ts#L48

* Any navigation within GH without a reload doesn't re-run the content-script. Thereby not running the `processGithubPage` function.

* Hence the [domUpdateWatch](https://github.com/open-sauced/ai/blob/554bdedef96f35b1e967d1dd2cd934b2158fcda2/src/utils/dom-utils/domUpdateWatcher.ts) utility was introduced that listens for page navigations and runs a callback with a specified delay in ms. The callback being `processGithubPage`.
https://github.com/open-sauced/ai/blob/554bdedef96f35b1e967d1dd2cd934b2158fcda2/src/content-scripts/github.ts#L45

* The multiple injection issue arises when a user navigates back to a page without a reload that was already processed by the content-script. Leading to re-injections.

* Initially we had utilized guards in all the injection scripts to resolve the issue. But this solution introduced redundancy and was prone to edge-cases like #87.
https://github.com/open-sauced/ai/blob/554bdedef96f35b1e967d1dd2cd934b2158fcda2/src/utils/dom-utils/viewOnOpenSauced.ts#L14-L16

* This solution resolves the issue using a `navigationHistory` set that holds the URLs navigated by the user. The `processGithubPage` returns without any injection if the page was already visited by the user and injections(if any) were done. All the injection guards can now be safely removed.
https://github.com/open-sauced/ai/blob/5a54b74dbaabf78d7a25a65f3ad2dd59101f498f/src/content-scripts/github.ts#L18-L26

* Like mentioned above, the content-script re-runs with every page reload, thereby resetting the `navigationHistory` set and the injected components are removed, re-injected as required.

Additionally, this PR, 
* Adds background-color, padding to the extension login page. 29d4212637928b4de0d5b2b5d694e2e154bc6543. 
* As mentioned in https://github.com/open-sauced/ai/pull/101#issuecomment-1559198667, removes the PR author check before injecting the "Add PR to highlights" button. 5a54b74dbaabf78d7a25a65f3ad2dd59101f498f.
 
## Related Tickets & Documents
Resolves #87.

## Mobile & Desktop Screenshots/Recordings

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed