### PR TITLE
feat: Manifest.json version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "☁️ checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "🔧 setup node"
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18.x
 
       - name: "🔧 install npm@latest"
         run: npm i -g npm@latest
@@ -62,7 +62,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "☁️ checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: "🚀 release"
         id: semantic-release
-        uses: open-sauced/release@v1
+        uses: open-sauced/release@v2.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR updates the release workflow to use the latest version of actions/checkout and actions/setup-node. Node version is updated to 18.x. The open-sauced/release action is updated to v2.1.0.

_Generated using [OpenSauced](https://opensauced.ai/)._

The updated release-action bumps the `version` value in the `manfest.json` file after each release. 

A working demo of the updated workflow can be found here: https://github.com/Anush008/release-test/actions/runs/5075094479.

Manifest.json version bump demo commit: https://github.com/Anush008/release-test/commit/8b79587aa6aac9326d4e4a2033097b63b4cfa999.

## Related Tickets & Documents
Resolves #53.

## Mobile & Desktop Screenshots/Recordings


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed