### PR TITLE
fix: bump manifest version on main only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: "🚀 release"
         id: semantic-release
-        uses: open-sauced/release@v2.1.0
+        uses: open-sauced/release@v2.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenSauced.ai",
-  "version": "1.2.0-beta.4",
+  "version": "0.0.1",
   "action": { "default_popup": "index.html" },
   "content_scripts": [
     {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR fixes #121 by updating the open-sauced/release action version to `v2.1.1` which has been updated with a patch to bump the `version`  value of the `manifest.json` file when a release is done on the `main` branch with integer-only version numbers.


Additionally, the `version` value of the `manifest.json` file has been reset.

Patch: https://github.com/open-sauced/release/pull/14

## Related Tickets & Documents
Resolves #121.

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed