### PR TITLE
feat: uses username on highlight instead of full name

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -23,6 +23,7 @@ interface Highlight {
     title: string;
     name: string;
     url: string;
+    login: string;
 }
 
 
@@ -61,11 +62,10 @@ const Home = () => {
 
     useEffect(() => {
         // Update the current name when the highlight changes
-        if (highlights[currentPage]?.name) {
-            setCurrentName(formatNameForLink(highlights[currentPage].name));
+        if (highlights[currentPage]?.login) {
+            setCurrentName(formatNameForLink(highlights[currentPage].login));
         }
     }, [highlights, currentPage]);
-
 
     return (
         <div className="p-4 bg-slate-800">
@@ -119,13 +119,13 @@ const Home = () => {
 
                                 <a
                                     className="text-blue-500 hover:text-blue-700 underline cursor-pointer"
-                                    href={`https://insights.opensauced.pizza/user/${formatNameForLink(highlights[currentPage]?.name)}`}
+                                    href={`https://insights.opensauced.pizza/user/${formatNameForLink(highlights[currentPage]?.login)}`}
                                     rel="noopener noreferrer"
                                     target="_blank"
 
 
                                 >
-                                    {highlights[currentPage]?.name}
+                                    {highlights[currentPage]?.login}
                                 </a>
                             </div>
 

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -58,12 +58,10 @@ const Home = () => {
         setCurrentPage(prevPage => prevPage + 1);
     };
 
-    const formatNameForLink = (name: string): string => name.replace(/\s/g, "");
-
     useEffect(() => {
         // Update the current name when the highlight changes
         if (highlights[currentPage]?.login) {
-            setCurrentName(formatNameForLink(highlights[currentPage].login));
+            setCurrentName(highlights[currentPage].login);
         }
     }, [highlights, currentPage]);
 
@@ -119,7 +117,7 @@ const Home = () => {
 
                                 <a
                                     className="text-blue-500 hover:text-blue-700 underline cursor-pointer"
-                                    href={`https://insights.opensauced.pizza/user/${formatNameForLink(highlights[currentPage]?.login)}`}
+                                    href={`https://insights.opensauced.pizza/user/${highlights[currentPage]?.login}`}
                                     rel="noopener noreferrer"
                                     target="_blank"
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR updates the Home page to display the user's login instead of their name in the Insights section. It also refactors the code to use the new login property in the Highlight interface. The link to the user's profile page now correctly uses the login property.

_Generated using [OpenSauced](https://opensauced.ai/)._
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
closes #160

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

<img width="334" alt="Screen Shot 2023-06-02 at 9 58 19 PM" src="https://github.com/open-sauced/ai/assets/5713670/68f8833e-8fc3-457a-bd69-c6518b3cbe08">

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<img src="https://media2.giphy.com/media/Lnco9DasvpSJYXJkV0/giphy.gif"/>