### PR TITLE
fix: highlight redirection, multiple AI generation, draft commit messages

### DIFF
--- a/src/content-scripts/components/AICodeRefactor/ChangeSuggestorButton.ts
+++ b/src/content-scripts/components/AICodeRefactor/ChangeSuggestorButton.ts
@@ -21,13 +21,15 @@ export const ChangeSuggestorButton = (commentNode: HTMLElement) => {
 };
 
 const handleSubmit = async (commentNode: HTMLElement) => {
+    const logo = document.getElementById("ai-description-button-logo");
+    const button = document.getElementById("os-ai-change-gen");
+
     try {
         if (!(await isLoggedIn())) {
             return window.open(SUPABASE_LOGIN_URL, "_blank");
         }
-        const logo = document.getElementById("ai-description-button-logo");
 
-        if (!logo) {
+        if (!logo || !button) {
             return;
         }
 
@@ -41,6 +43,7 @@ const handleSubmit = async (commentNode: HTMLElement) => {
         }
 
         logo.classList.toggle("animate-spin");
+        button.classList.toggle("pointer-events-none");
 
         const selectedLines = document.querySelectorAll(".code-review.selected-line");
         let selectedCode = Array.from(selectedLines).map(line => line.textContent)
@@ -69,6 +72,7 @@ const handleSubmit = async (commentNode: HTMLElement) => {
         );
 
         logo.classList.toggle("animate-spin");
+        button.classList.toggle("pointer-events-none");
         if (!suggestionStream) {
             return console.error("No description was generated!");
         }
@@ -76,6 +80,9 @@ const handleSubmit = async (commentNode: HTMLElement) => {
 
         insertTextAtCursor(textArea as HTMLTextAreaElement, suggestionStream);
     } catch (error: unknown) {
+        logo?.classList.toggle("animate-spin");
+        button?.classList.toggle("pointer-events-none");
+
         if (error instanceof Error) {
             console.error("Description generation error:", error.message);
         }

--- a/src/content-scripts/components/GenerateAIDescription/DescriptionGeneratorButton.ts
+++ b/src/content-scripts/components/GenerateAIDescription/DescriptionGeneratorButton.ts
@@ -23,26 +23,30 @@ export const DescriptionGeneratorButton = () => {
 };
 
 const handleSubmit = async () => {
-    const logo = document.getElementById("ai-description-button-logo") ?? null;
+    const logo = document.getElementById("ai-description-button-logo");
+    const button = document.getElementById("ai-description-button");
 
     try {
         if (!(await isLoggedIn())) {
             return window.open(SUPABASE_LOGIN_URL, "_blank");
         }
 
-        if (!logo) {
+        if (!logo || !button) {
             return;
         }
         logo.classList.toggle("animate-spin");
+        button.classList.toggle("pointer-events-none");
         const descriptionStream = await getAiDescription();
 
         logo.classList.toggle("animate-spin");
+        button.classList.toggle("pointer-events-none");
 
         const textArea = document.getElementsByName(GITHUB_PR_COMMENT_TEXT_AREA_SELECTOR)[0] as HTMLTextAreaElement;
 
         insertTextAtCursor(textArea, descriptionStream);
     } catch (error: unknown) {
         logo?.classList.toggle("animate-spin");
+        button?.classList.toggle("pointer-events-none");
 
         if (error instanceof Error) {
             alert(error.message);
@@ -53,6 +57,7 @@ const handleSubmit = async () => {
 
 export const getAiDescription = async () => {
     const url = getPullRequestAPIURL(window.location.hostname + window.location.pathname);
+
     const descriptionConfig = await getAIDescriptionConfig();
 
     if (!descriptionConfig) {
@@ -88,4 +93,7 @@ export const getAiDescription = async () => {
 
     return descriptionStream;
 };
+
+
+
 

--- a/src/content-scripts/components/GenerateAIDescription/DescriptionGeneratorButton.ts
+++ b/src/content-scripts/components/GenerateAIDescription/DescriptionGeneratorButton.ts
@@ -56,7 +56,8 @@ const handleSubmit = async () => {
 };
 
 export const getAiDescription = async () => {
-    const url = getPullRequestAPIURL(window.location.hostname + window.location.pathname);
+    const { protocol, hostname, pathname } = window.location;
+    const url = getPullRequestAPIURL(`${protocol}//${hostname}${pathname}`);
 
     const descriptionConfig = await getAIDescriptionConfig();
 
@@ -93,7 +94,5 @@ export const getAiDescription = async () => {
 
     return descriptionStream;
 };
-
-
 
 

--- a/src/content-scripts/components/GenerateAIDescription/DescriptionGeneratorButton.ts
+++ b/src/content-scripts/components/GenerateAIDescription/DescriptionGeneratorButton.ts
@@ -52,7 +52,7 @@ const handleSubmit = async () => {
 };
 
 export const getAiDescription = async () => {
-    const url = getPullRequestAPIURL(window.location.href);
+    const url = getPullRequestAPIURL(window.location.hostname + window.location.pathname);
     const descriptionConfig = await getAIDescriptionConfig();
 
     if (!descriptionConfig) {

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -18,27 +18,22 @@ import { getHighlights } from "../utils/fetchOpenSaucedApiData";
 
 import Help from "./help";
 import { OPEN_SAUCED_INSIGHTS_DOMAIN } from "../constants";
-interface Highlight {
-    highlight: string;
-    title: string;
-    name: string;
-    url: string;
-    login: string;
-}
-
+import type { Highlight } from "../ts/types";
 
 const Home = () => {
     const { user } = useAuth();
     const { currentTabIsOpensaucedUser, checkedUser } = useOpensaucedUserCheck();
     const [highlights, setHighlights] = useState<Highlight[]>([]);
     const [currentPage, setCurrentPage] = useState(0);
-    const [currentName, setCurrentName] = useState<string>("");
-
 
     useEffect(() => {
         const fetchHighlights = async () => {
             try {
                 const userHighlightsData = await getHighlights();
+
+                if (!userHighlightsData) {
+                    return;
+                }
                 const highlights = userHighlightsData.data;
 
                 setHighlights(highlights);
@@ -57,13 +52,6 @@ const Home = () => {
     const handleNext = () => {
         setCurrentPage(prevPage => prevPage + 1);
     };
-
-    useEffect(() => {
-        // Update the current name when the highlight changes
-        if (highlights[currentPage]?.login) {
-            setCurrentName(highlights[currentPage].login);
-        }
-    }, [highlights, currentPage]);
 
     return (
         <div className="p-4 bg-slate-800">

--- a/src/pages/posthighlight.tsx
+++ b/src/pages/posthighlight.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../hooks/useAuth";
 import toast, { Toaster } from "react-hot-toast";
 import { cerateHighlight } from "../utils/fetchOpenSaucedApiData";
 import { goBack } from "react-chrome-extension-router";
+import { OPEN_SAUCED_INSIGHTS_DOMAIN } from "../constants";
 
 const PostOnHighlight = () => {
     const { authToken, user } = useAuth();
@@ -42,7 +43,7 @@ const PostOnHighlight = () => {
                 return (
                     <span>
                         <a
-                            href={`https://insights.opensauced.pizza/user/${user?.user_name}/highlights`}
+                            href={`${OPEN_SAUCED_INSIGHTS_DOMAIN}/user/${user?.user_name}/highlights`}
                             rel="noreferrer"
                             target="_blank"
                         >

--- a/src/pages/posthighlight.tsx
+++ b/src/pages/posthighlight.tsx
@@ -43,7 +43,7 @@ const PostOnHighlight = () => {
                 return (
                     <span>
                         <a
-                            href={`${OPEN_SAUCED_INSIGHTS_DOMAIN}/user/${user?.user_name}/highlights`}
+                            href={`https://${OPEN_SAUCED_INSIGHTS_DOMAIN}/user/${user?.user_name}/highlights`}
                             rel="noreferrer"
                             target="_blank"
                         >

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -17,3 +17,33 @@ export interface IUserPR {
     readonly changed_files: number;
     readonly repo_id: number;
 }
+
+export interface Highlights {
+    data: Highlight[];
+    meta: HighlightsMeta;
+}
+
+export interface Highlight {
+    id: number;
+    user_id: number;
+    url: string;
+    title: string;
+    highlight: string;
+    pinned: boolean;
+    created_at: string;
+    updated_at: string;
+    deleted_at: string;
+    shipped_at: string;
+    full_name: string;
+    name: string;
+    login: string;
+}
+
+interface HighlightsMeta {
+    page: number;
+    limit: number;
+    itemCount: number;
+    pageCount: number;
+    hasPreviousPage: boolean;
+    hasNextPage: boolean;
+}

--- a/src/utils/fetchOpenSaucedApiData.ts
+++ b/src/utils/fetchOpenSaucedApiData.ts
@@ -8,6 +8,7 @@ import {
     OPEN_SAUCED_HIGHLIGHTS_ENDPOINT,
 } from "../constants";
 import { IInsight } from "../ts/InsightDto";
+import { Highlights } from "../ts/types";
 
 export const isOpenSaucedUser = async (username: string) => {
     try {
@@ -178,12 +179,18 @@ export const updateInsight = async (userToken: string, repoId: string, checked: 
 
     return response.status === 200;
 };
-export const getHighlights = async () => {
-    const response = await fetch(
+export const getHighlights = async (): Promise<Highlights | undefined> => {
+    const response = await cachedFetch(
         `${OPEN_SAUCED_HIGHLIGHTS_ENDPOINT}`,
-        { method: "GET" },
+        {
+            method: "GET",
+            expireInSeconds: 300,
+        },
     );
 
+    if (!response) {
+        return;
+    }
     return response.json();
 };
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
* Resolves #131 by passing the PR URL without any query params or IDs. With this update,  appending `/commits` to the endpoint, the current inability to get commit messages of draft PRs mentioned at https://github.com/open-sauced/ai/pull/79#issuecomment-1552287192 will be resolved. https://github.com/open-sauced/ai/blob/b697b701b9c299e5b02ba13491e249e8dafae668/src/utils/fetchGithubAPIData.ts#L23-L24 d1429b6f4a747a3b6ff5c66695738b15954ce759.

* Resolves #153 by updating `href` to the configured domain. b6f1dd0b2e72e9e505e3ef8a10a258c7ad23382c.

* Resolves #119 by disabling the button events when the AI generation is underway. fc26ef8fdd6acfb1b0826d7773a2136e0e0a8bbb.

* Additionally, refactors the latest highlight feat, moves the `Highlights` type definition to the types file for reusability, uses `cachedFetch()` for getting the highlights. b2ec143edf7eee8c05769fa142ecb276b03dd347

## Related Tickets & Documents
closes #131
closes #153 
closes #119

## Mobile & Desktop Screenshots/Recordings


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed