### PR TITLE
fix: remove configuration enabled check from AI button

### DIFF
--- a/src/content-scripts/components/GenerateAIDescription/DescriptionGeneratorButton.ts
+++ b/src/content-scripts/components/GenerateAIDescription/DescriptionGeneratorButton.ts
@@ -73,10 +73,6 @@ export const getAiDescription = async (prUrl: string) => {
         throw new Error("Configuration file is empty!");
     }
 
-    if (!descriptionConfig.enabled) {
-        throw new Error("AI PR description is disabled!");
-    }
-
     const [diff, commitMessages] = await getDescriptionContext(prApiUrl, descriptionConfig.config.source);
 
     if (!diff && !commitMessages) {


### PR DESCRIPTION
FIx for https://github.com/open-sauced/ai/pull/168#issuecomment-1577971689

It didn't work because descriptionConfig.enabled never existed.

We do this via sync storage now -[beta/src/utils/dom-utils/addDescriptionGenerator.ts#L18](https://github.com/open-sauced/ai/blob/beta/src/utils/dom-utils/addDescriptionGenerator.ts?rgh-link-date=2023-06-06T08%3A28%3A12Z#L18)