### PR TITLE
fix: separate vite and vitest configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,7 @@ module.exports = {
 		jest: true,
 		es2021: true,
 	},
-	ignorePatterns: ["test", "dist", "build", "public", "/**/node_modules/*", ".eslintrc.js", "vite.config.ts", "vite-env.d.ts", "postcss.config.js", "tailwind.config.js"],
+	ignorePatterns: ["test", "dist", "build", "public", "/**/node_modules/*", ".eslintrc.js", "vite.config.ts", "vite-env.d.ts", "postcss.config.js", "tailwind.config.js", "vitest.config.ts"],
 	rules: {
 		"indent": "off",
 		"@typescript-eslint/indent": "error",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,9 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { crx } from "@crxjs/vite-plugin";
-import manifest from "./manifest.json" assert { type: "json" };
+import * as manifest from "./manifest.json";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  test: {
-    environment: "jsdom",
-  },
+  plugins: [react(), crx({ manifest } as any)],
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+});


### PR DESCRIPTION
Fix for https://discordapp.com/channels/714698561081704529/928693344358514698/1121122996384432148, an issue where the build had not manifest.json because of incorrect vite config.

This PR updates the `.eslintrc.js` file to include `vitest.config.ts` in the `ignorePatterns` array. It also updates the `vite.config.ts` file to import `defineConfig` from `vite` instead of `vitest/config`. Additionally, it removes the `test` object from the `vite.config.ts` file and creates a new `vitest.config.ts` file to configure the testing environment.

_Generated using [OpenSauced](https://opensauced.ai/)._

