### PR TITLE
fix: Multiple button injections

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1285,9 +1285,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1430,9 +1430,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1511,9 +1511,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2372,9 +2372,9 @@
       }
     },
     "node_modules/concordance/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6195,11 +6195,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -7431,9 +7430,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"

--- a/src/hooks/useGetGitHubPageInfo.ts
+++ b/src/hooks/useGetGitHubPageInfo.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { isGithubPullRequestPage, isGithubRepoPage } from "../utils/urlMatchers";
+import { isPublicRepository } from "../utils/fetchGithubAPIData";
 
 interface GitHubPageInfo {
     pageUrl: string;
@@ -11,13 +12,13 @@ export const usGetGitHubPageInfo = () => {
     const [GithubPage, setGithubPage] = useState<GitHubPageInfo>({ pageUrl: "", pageTitle: "", type: "unknown" });
 
     useEffect(() => {
-        chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+        chrome.tabs.query({ active: true, currentWindow: true }, async tabs => {
             if (tabs.length > 0) {
                 const tab = tabs[0];
 
                 if (isGithubPullRequestPage(tab.url!)) {
                     setGithubPage({ pageUrl: tab.url!, pageTitle: tab.title!.split("by")[0].trim(), type: "PR" });
-                } else if (isGithubRepoPage(tab.url!)) {
+                } else if (isGithubRepoPage(tab.url!) && (await isPublicRepository(tab.url!))) {
                     setGithubPage({ pageUrl: tab.url!, pageTitle: "", type: "REPO" });
                 }
             }

--- a/src/utils/dom-utils/prWatcher.ts
+++ b/src/utils/dom-utils/prWatcher.ts
@@ -1,3 +1,5 @@
+import domUpdateWatch from "./domUpdateWatcher";
+
 const prEditWatch = (callback: () => void, delayInMs = 0) => {
     const observer = new MutationObserver((mutationList: MutationRecord[], observer: MutationObserver) => {
         mutationList.forEach(mutation => {
@@ -6,6 +8,11 @@ const prEditWatch = (callback: () => void, delayInMs = 0) => {
                 observer.disconnect();
             }
         });
+    });
+
+    // Disconnect the observer when the user navigates to a new page
+    domUpdateWatch(() => {
+        observer.disconnect();
     });
 
     observer.observe(document.body, { attributes: true, subtree: true });


### PR DESCRIPTION
## Description
* Update npm-shrinkwrap.json to use version 7.5.4 of semver package. 
* Update useGetGitHubPageInfo.ts to check if the repository is public before setting the page type as `"REPO"`. 
* Add a new import statement for `domUpdateWatcher` in prWatcher.ts and disconnect the observer when the user navigates to a new page.

_Generated using [OpenSauced](https://opensauced.ai/)._

The issue of multiple buttons arises due to the instantiation of multiple mutation observers while a user navigates back and forth on pull request pages, which should be resolved now.

Additonally, as mentioned in https://github.com/open-sauced/ai/issues/217#issuecomment-1636822365, a public repository check has been added before rendering the "Add project to LinkedIn" button.


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
Fixes #217, #227.

## Mobile & Desktop Screenshots/Recordings
**RESOLVES THE FOLLOWING REPORTED CASES**:

![Untitled2](https://github.com/open-sauced/ai/assets/46051506/f0ada202-a872-4a09-b959-260afeeefe32)
![Untitled2-2](https://github.com/open-sauced/ai/assets/46051506/d7b2da32-b277-4c2b-a4c3-c0abc31e2878)


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed