### PR TITLE
fix: login to the website after rename

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
-VITE_OPEN_SAUCED_INSIGHTS_DOMAIN = "beta.insights.opensauced.pizza"
+VITE_OPEN_SAUCED_INSIGHTS_DOMAIN = "beta.app.opensauced.pizza"
 VITE_OPEN_SAUCED_API_ENDPOINT = "https://beta.api.opensauced.pizza/v1"
 VITE_OPEN_SAUCED_SUPABASE_ID = "fcqqkxwlntnrtjfbcioz"

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,3 @@
-VITE_OPEN_SAUCED_INSIGHTS_DOMAIN = "insights.opensauced.pizza"
+VITE_OPEN_SAUCED_INSIGHTS_DOMAIN = "app.opensauced.pizza"
 VITE_OPEN_SAUCED_API_ENDPOINT = "https://api.opensauced.pizza/v1"
 VITE_OPEN_SAUCED_SUPABASE_ID = "ibcwmlhcimymasokhgvn"

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,3 @@
-VITE_OPEN_SAUCED_INSIGHTS_DOMAIN = "beta.insights.opensauced.pizza"
+VITE_OPEN_SAUCED_INSIGHTS_DOMAIN = "beta.app.opensauced.pizza"
 VITE_OPEN_SAUCED_API_ENDPOINT = "https://beta.api.opensauced.pizza/v1"
 VITE_OPEN_SAUCED_SUPABASE_ID = "fcqqkxwlntnrtjfbcioz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
   release:
     environment:
       name: ${{ needs.setup.outputs.DEPLOY_ENVIRONMENT }}
-      url: https://${{ needs.setup.outputs.DEPLOY_SUBDOMAIN }}insights.opensauced.pizza
+      url: https://${{ needs.setup.outputs.DEPLOY_SUBDOMAIN }}app.opensauced.pizza
     name: Semantic release
     needs:
       - setup

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,6 @@
     "48": "src/assets/os-icons/os-icon-48.png",
     "128": "src/assets/os-icons/os-icon-128.png"
   },
-  "host_permissions": ["https://github.com/*", "https://*.insights.opensauced.pizza/*" , "https://www.linkedin.com/*"],
+  "host_permissions": ["https://github.com/*", "https://*.app.opensauced.pizza/*" , "https://www.linkedin.com/*"],
   "permissions": ["scripting", "storage", "tabs", "cookies"]
 }

--- a/src/popup/components/HighlightSlide.tsx
+++ b/src/popup/components/HighlightSlide.tsx
@@ -92,7 +92,7 @@ export const HighlightSlide = ({ highlight, emojis }: HighlightSlideProps) => {
 
                 <a
                     className="text-orange cursor-pointer"
-                    href={`https://insights.opensauced.pizza/user/${login}`}
+                    href={`https://app.opensauced.pizza/user/${login}`}
                     rel="noopener noreferrer"
                     target="_blank"
                 >


### PR DESCRIPTION
## Description

This PR fix the issue of not being able to login to the extension due the rename of insights website to app. 
I think we need to add tests as well though. 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #271

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?


<img src="https://media2.giphy.com/media/fBEMsUeGHdpsClFsxM/giphy.gif"/>