### PR TITLE
fix: test driftage

### DIFF
--- a/test/api/openSaucedApi.test.ts
+++ b/test/api/openSaucedApi.test.ts
@@ -18,7 +18,6 @@ describe("openSaucedUserEndpoint", () => {
         const response = await fetch(`${OPEN_SAUCED_USERS_ENDPOINT}/foolala`);
         expect(response.status).toBe(400);
     })
-    })
 })
 
 describe("openSaucedRepoEndpoint", () => {

--- a/test/api/openSaucedApi.test.ts
+++ b/test/api/openSaucedApi.test.ts
@@ -14,9 +14,10 @@ describe("openSaucedUserEndpoint", () => {
         expect(data.login).toBe("bdougie");
     })
 
-    it("should not return a 200 error for a user that does not exist", async () => {
+    it("should return a bad request for a user that does not exist", async () => {
         const response = await fetch(`${OPEN_SAUCED_USERS_ENDPOINT}/foolala`);
-        expect(response.status).not.toBe(200);
+        expect(response.status).toBe(400);
+    })
     })
 })
 

--- a/test/api/openSaucedApi.test.ts
+++ b/test/api/openSaucedApi.test.ts
@@ -14,9 +14,9 @@ describe("openSaucedUserEndpoint", () => {
         expect(data.login).toBe("bdougie");
     })
 
-    it("should return a 404 error for a user that does not exist", async () => {
-        const response = await fetch(`${OPEN_SAUCED_USERS_ENDPOINT}/1`);
-        expect(response.status).toBe(404);
+    it("should not return a 200 error for a user that does not exist", async () => {
+        const response = await fetch(`${OPEN_SAUCED_USERS_ENDPOINT}/foolala`);
+        expect(response.status).not.toBe(200);
     })
 })
 

--- a/test/utils/urlMatcher.test.ts
+++ b/test/utils/urlMatcher.test.ts
@@ -98,7 +98,7 @@ test('getPullRequestAPIURL', async () => {
   expect(await getPullRequestAPIURL('https://github.com/open-sauced/ai/pull/164')).toBe('https://api.github.com/repos/open-sauced/ai/pulls/164')
   expect(await getPullRequestAPIURL('https://github.com/open-sauced/ai/pull/163')).toBe('https://api.github.com/repos/open-sauced/ai/pulls/163')
   expect(await getPullRequestAPIURL('https://github.com/open-sauced/ai/compare/some-branch')).toBe('https://api.github.com/repos/open-sauced/ai/compare/beta...some-branch')
-  expect(await getPullRequestAPIURL('https://github.com/tailwindlabs/tailwindcss/compare/some-branch')).toBe('https://api.github.com/repos/tailwindlabs/tailwindcss/compare/master...some-branch')
+  expect(await getPullRequestAPIURL('https://github.com/tailwindlabs/tailwindcss/compare/some-branch')).toBe('https://api.github.com/repos/tailwindlabs/tailwindcss/compare/next...some-branch')
   expect(await getPullRequestAPIURL('https://github.com/open-sauced/ai/compare/beta...some-branch')).toBe('https://api.github.com/repos/open-sauced/ai/compare/beta...some-branch')
   expect(await getPullRequestAPIURL('https://github.com/tailwindlabs/tailwindcss/compare/master...some-branch')).toBe('https://api.github.com/repos/tailwindlabs/tailwindcss/compare/master...some-branch')
   


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

Saw test were failing on a benign change on #310. This fixes the user 404 test and Tailwind's default branch change.

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

#310
#309 
#308 

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
npm test

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExd2l1bGV6eml4MjV6MngxNmxtcHBiMzU4dzhqNXJlc3pjNGs5a3Z0OCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/zGIu2ez2XD5qfflDZf/giphy.webp)