### PR TITLE
fix: Generates a token so the open-sauce bot can push to beta

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.OS_GITHUB_APP_ID }}
+          private_key: ${{ secrets.OS_GITHUB_APP_PRIVATE_KEY }}
+
+    steps:
       - name: "☁️ checkout repository"
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: "📂 download build artifacts"
         uses: actions/download-artifact@v2
@@ -70,9 +79,9 @@ jobs:
 
       - name: "🚀 release"
         id: semantic-release
-        uses: open-sauced/release@v2.1.1
+        uses: open-sauced/release@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
   cleanup:
     name: Cleanup actions


### PR DESCRIPTION
## Description

There are failing release actions: https://github.com/open-sauced/ai/actions/runs/10460890612/job/28969268401 because the bot isn't able to push to `beta`. This corrects this by using the generate token step we use elsewhere.

## Related Tickets & Documents

N/a - followup to Brian's cleanup work

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4